### PR TITLE
Print a link to the Step Function execution

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,6 +15,7 @@ end
 # One of: "RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"
 if deployment_status == 'RUNNING'
   puts 'Deployment in progress...🔄'
+  puts "Monitor at https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{ENV['EXECUTION_ARN']}"
   sleep 15 until deployment_status != 'RUNNING'
 end
 


### PR DESCRIPTION
If a deployment fails, users will be notified on Slack and this is the
step that'll be opened in the Github Action -- adding a link makes it
easier to then investigate from there.

Tested successfully here (the deployment failed for another reason, the text works though): https://github.com/fac/banksy/runs/7110256915?check_suite_focus=true
