### PR TITLE
Make use of action outputs and report on deploy failure reason

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  specs:
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.2.0)
+    aws-partitions (1.702.0)
+    aws-sdk-core (3.170.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-states (1.52.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    jmespath (1.6.2)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  aws-sdk-states!
+
+BUNDLED WITH
+   2.3.7

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ GitHub Action used to monitor AWS StepFunction deployments.
 
 The StepFunction execution arn that you wish to track the status of.
 
+
+## Development
+
+Install locally with 
+
+```bash
+bundle install
+```
+
+Then, if you have an AWS StepFunction execution ARN you can test the logic as follows:
+
+```bash
+export EXECUTION_ARN=arn:aws:states:eu-west-1:123456789012:execution:example-state-machine:12345678-9012-3456-7890-123456789012
+ruby app.rb # Remember to take care of authentication with AWS. For example, if you are using vault, then you could execute `aws-vault exec myprofile -- ruby app.rb
+```
+
 ## Authors
 
 * FreeAgent Ops opensource@freeagent.com

--- a/action.yml
+++ b/action.yml
@@ -6,3 +6,8 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.EXECUTION_ARN }}
+outputs:
+  deployment_failed:
+    description: True or false depending on whether the deployment failed
+  deployment_failure_reason:
+    description: A brief explanation on why the deployment failed

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-states'
+require 'json'
 
 STDOUT.sync = true
 
@@ -7,22 +8,43 @@ if ENV['EXECUTION_ARN'].nil?
   exit 1
 end
 
-def deployment_status
-  aws_client = Aws::States::Client.new(region: 'eu-west-1')
+aws_client = Aws::States::Client.new(region: 'eu-west-1')
+
+def deployment_status(aws_client)
   aws_client.describe_execution({ execution_arn: ENV['EXECUTION_ARN'] }).status
 end
 
-# One of: "RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"
-if deployment_status == 'RUNNING'
-  puts 'Deployment in progress...🔄'
-  puts "Monitor at https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{ENV['EXECUTION_ARN']}"
-  sleep 15 until deployment_status != 'RUNNING'
+def failure_reason(aws_client)
+  resp = aws_client.get_execution_history({
+    execution_arn: ENV['EXECUTION_ARN'],
+    max_results: 2,
+    reverse_order: true
+  })
+  error_message = JSON.parse(JSON.parse(resp.events[1].state_entered_event_details.input)['Error']['Cause'])['errorMessage']
+
+  if error_message.include? "ECS" and error_message.include? "IN_PROGRESS"
+    deploy_fail_reason = "Sidekiq workers failed to start or failed to stabilise."
+  else
+    deploy_fail_reason = "Unknown. Please investigate here https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{ENV['EXECUTION_ARN']}"
+  end
+
+  return deploy_fail_reason
 end
 
-if %w[FAILED TIMED_OUT ABORTED].include?(deployment_status)
-  puts "Deployment Failure Status: #{deployment_status} ❌"
-  exit 1
-elsif deployment_status == 'SUCCEEDED'
+# One of: "RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"
+if deployment_status(aws_client) == 'RUNNING'
+  puts 'Deployment in progress...🔄'
+  puts "Monitor at https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{ENV['EXECUTION_ARN']}"
+  sleep 15 until deployment_status(aws_client) != 'RUNNING'
+end
+
+deploy_status = deployment_status(aws_client)
+if %w[FAILED TIMED_OUT ABORTED].include?(deploy_status)
+  puts "Deployment Failure Status: #{deploy_status} ❌"
+  File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+    f.puts "deployment_failed=true"
+    f.puts "deployment_failure_reason=#{failure_reason(aws_client)}"
+  end
+elsif deploy_status == 'SUCCEEDED'
   puts 'Deployment Successful 🎉'
-  exit 0
 end


### PR DESCRIPTION
As things stand, if a deployment fails we also fail the monitoring action which conceptually is not ideal.
In this PR we ensure the monitoring action completes successfully (unless it truly fails) and also attempts to capture a more specific reason for a deploy failure and report it via a GH action output.

Note: BREAKING CHANGE - this is a potentially breaking change as we no longer fail the monitoring action if the 
deployment has failed. Any upstream GH actions will have to be adapted to deal with this interface change.
For an example on what kind of adaptation may be required see this PR concerning freeagent deploys @stage 
https://github.com/fac/freeagent/pull/41712/files#diff-beb5c5b5af7ffac29fdf8cdb68f502d5261086e8a0eb93e158f96d29d0ed9d67R120
(Still WIP at the time of raising the current PR)

Part of https://github.com/fac/platform-issues/issues/2054