### PR TITLE
Better slack reporting when pre-flight checks fail

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,47 +3,56 @@ require 'json'
 
 STDOUT.sync = true
 
-if ENV['EXECUTION_ARN'].nil?
+execution_arn = ENV['EXECUTION_ARN']
+
+if execution_arn.nil?
   puts 'EXECUTION_ARN is required. Please set it as an ENV Variable.'
   exit 1
 end
 
 aws_client = Aws::States::Client.new(region: 'eu-west-1')
 
-def deployment_status(aws_client)
-  aws_client.describe_execution({ execution_arn: ENV['EXECUTION_ARN'] }).status
+def deployment_status(aws_client, execution_arn)
+  aws_client.describe_execution({ execution_arn: execution_arn }).status
 end
 
-def failure_reason(aws_client)
+def failure_reason(aws_client, execution_arn)
   resp = aws_client.get_execution_history({
-    execution_arn: ENV['EXECUTION_ARN'],
+    execution_arn: execution_arn,
     max_results: 2,
     reverse_order: true
   })
-  error_message = JSON.parse(JSON.parse(resp.events[1].state_entered_event_details.input)['Error']['Cause'])['errorMessage']
 
-  if error_message.include? "ECS" and error_message.include? "IN_PROGRESS"
-    deploy_fail_reason = "Sidekiq workers failed to start or failed to stabilise."
+  event_type = resp.events[1].type
+  if event_type == "LambdaFunctionFailed"
+    deploy_fail_reason = JSON.parse(resp.events[1].lambda_function_failed_event_details.cause)['errorMessage']
+  elsif event_type == "FailStateEntered"
+    error_message = JSON.parse(JSON.parse(resp.events[1].state_entered_event_details.input)['Error']['Cause'])['errorMessage']
+    if error_message.include? "ECS" and error_message.include? "IN_PROGRESS"
+      deploy_fail_reason = "Sidekiq workers failed to start or failed to stabilise."
+    else
+      deploy_fail_reason = "Failure message: #{error_message}. Please investigate further here if required https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{execution_arn}"
+    end
   else
-    deploy_fail_reason = "Unknown. Please investigate here https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{ENV['EXECUTION_ARN']}"
+    deploy_fail_reason = "Uncaught failure. Please investigate here https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{execution_arn}"
   end
 
   return deploy_fail_reason
 end
 
 # One of: "RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"
-if deployment_status(aws_client) == 'RUNNING'
+if deployment_status(aws_client, execution_arn) == 'RUNNING'
   puts 'Deployment in progress...🔄'
-  puts "Monitor at https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{ENV['EXECUTION_ARN']}"
-  sleep 15 until deployment_status(aws_client) != 'RUNNING'
+  puts "Monitor at https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/#{execution_arn}"
+  sleep 15 until deployment_status(aws_client, execution_arn) != 'RUNNING'
 end
 
-deploy_status = deployment_status(aws_client)
+deploy_status = deployment_status(aws_client, execution_arn)
 if %w[FAILED TIMED_OUT ABORTED].include?(deploy_status)
   puts "Deployment Failure Status: #{deploy_status} ❌"
   File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
     f.puts "deployment_failed=true"
-    f.puts "deployment_failure_reason=#{failure_reason(aws_client)}"
+    f.puts "deployment_failure_reason=#{failure_reason(aws_client, execution_arn)}"
   end
 elsif deploy_status == 'SUCCEEDED'
   puts 'Deployment Successful 🎉'


### PR DESCRIPTION
At the moment if preflight checks fail (for example a forward deploy check) this is not clear in slack.
With this PR we make sure that the specific failure is reported back from this action which then is captured at the calling GH action and reported back to slack.

See this slack thread demonstrating the problem we are trying to address with this PR https://freeagent.slack.com/archives/C0DT7DGS1/p1676385750719519