### PR TITLE
Update to better handle pre-flight errors

### DIFF
--- a/lib/deployment/events/lambda_function_failed.rb
+++ b/lib/deployment/events/lambda_function_failed.rb
@@ -7,30 +7,27 @@ module Deployment
       end
 
       def error
-        if preflight_checks_failed? && forward_deploy_check_failed?
-          'Forward deploy check FAILED. No need to panic! '\
-          'This likely means your commit has already been deployed as part of a previous deploy. '\
-          'To confirm you can check whether your SHA is a parent commit to the currently deployed SHA. '\
-          'You can figure out the currently deployed SHA by following this guide https://www.notion.so/freeagent/Deployment-Runbooks-29796221387e40b7abbb217d7d33c4ac?pvs=4#3bfa2ab5d3ab4c33b7a46522027f94bb'
-        elsif preflight_checks_failed?
-          preflight_checks_output.to_json
+        if preflight_checks_failed?
+          "The following pre-flight checks have failed: #{preflight_checks_failed.join(', ')}. "\
+          'See https://www.notion.so/freeagent/Deployment-Playbooks-aa0f91db24954b328ebfc7d87963a185#3193a48ea76e46b29a38027150612b0d'
         else
           @error_message
         end
       end
 
       private
+
       def preflight_checks_failed?
         @error_message.include? 'Pre flight checks failed'
       end
 
-      def preflight_checks_output
-        # This is horrible and dangerous but we control the input from the lambda. Ideally we should fix there but for now.
-        eval(@error_message.split("\n")[1])["Checks"]
+      def preflight_checks_failed
+        preflight_checks_output.select { |_k, v| v == 'FAILED' }.keys.sort
       end
 
-      def forward_deploy_check_failed?
-        preflight_checks_output[:ForwardDeployCheck] == 'FAILED'
+      def preflight_checks_output
+        # This is horrible and dangerous but we control the input from the lambda. Ideally we should fix there but for now.
+        eval(@error_message.split("\n")[1])['Checks']
       end
     end
   end

--- a/lib/deployment/events/lambda_function_failed.rb
+++ b/lib/deployment/events/lambda_function_failed.rb
@@ -3,6 +3,7 @@ module Deployment
     class LambdaFunctionFailed
       def initialize(event)
         @event = event
+        @error_message = JSON.parse(@event.lambda_function_failed_event_details.cause)['errorMessage']
       end
 
       def error
@@ -11,31 +12,25 @@ module Deployment
           'This likely means your commit has already been deployed as part of a previous deploy. '\
           'To confirm you can check whether your SHA is a parent commit to the currently deployed SHA. '\
           'You can figure out the currently deployed SHA by following this guide https://www.notion.so/freeagent/Deployment-Runbooks-29796221387e40b7abbb217d7d33c4ac?pvs=4#3bfa2ab5d3ab4c33b7a46522027f94bb'
+        elsif preflight_checks_failed?
+          preflight_checks_output.to_json
         else
-          error_message
+          @error_message
         end
       end
 
       private
-
-      def error_message
-        @error_message ||= JSON.parse(@event.lambda_function_failed_event_details.cause)['errorMessage']
+      def preflight_checks_failed?
+        @error_message.include? 'Pre flight checks failed'
       end
 
       def preflight_checks_output
-        error_message.lines[1]
-      end
-
-      def preflight_checks_failed?
-        error_message.include? 'Pre flight checks failed'
-      end
-
-      def forward_deploy_check_result
-        preflight_checks_output.match(/ForwardDeployCheck=>"(.*?)"/i).captures[0]
+        # This is horrible and dangerous but we control the input from the lambda. Ideally we should fix there but for now.
+        eval(@error_message.split("\n")[1])["Checks"]
       end
 
       def forward_deploy_check_failed?
-        forward_deploy_check_result == 'FAILED'
+        preflight_checks_output[:ForwardDeployCheck] == 'FAILED'
       end
     end
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -66,10 +66,8 @@ RSpec.describe 'app' do
         [
           "deployment_failed=true\n",
           'deployment_failure_reason=' \
-            'Forward deploy check FAILED. No need to panic! '\
-            'This likely means your commit has already been deployed as part of a previous deploy. '\
-            'To confirm you can check whether your SHA is a parent commit to the currently deployed SHA. '\
-            "You can figure out the currently deployed SHA by following this guide https://www.notion.so/freeagent/Deployment-Runbooks-29796221387e40b7abbb217d7d33c4ac?pvs=4#3bfa2ab5d3ab4c33b7a46522027f94bb\n"
+          'The following pre-flight checks have failed: ForwardDeployCheck. '\
+          "See https://www.notion.so/freeagent/Deployment-Playbooks-aa0f91db24954b328ebfc7d87963a185#3193a48ea76e46b29a38027150612b0d\n"
         ]
       )
     end

--- a/spec/deployment_spec.rb
+++ b/spec/deployment_spec.rb
@@ -157,7 +157,19 @@ RSpec.describe Deployment::Deployment do
         Aws::States::Types::GetExecutionHistoryOutput.new(
           events: [
             '',
-            Aws::States::Types::HistoryEvent.new(type: 'LambdaFunctionFailed')
+            Aws::States::Types::HistoryEvent.new(
+              type: 'LambdaFunctionFailed',
+              lambda_function_failed_event_details: Aws::States::Types::LambdaFunctionFailedEventDetails.new(
+                cause: '
+                  {
+                    "errorMessage": "Pre flight checks failed:\n{\"Checks\"=>{:RequiredParameters=>\"PASSED\", :CommitCheck=>\"PASSED\", :ScheduleCheck=>\"PASSED\", :ForwardDeployCheck=>\"FAILED\"}, \"Status\"=>\"FAILED\"}",
+                    "errorType": "Function<StandardError>",
+                    "stackTrace": [
+                      "/var/task/pre_flight_checks.rb:145:in `handler"
+                    ]
+                  }'
+              )
+            )
           ]
         )
       end

--- a/spec/lambda_function_failed_spec.rb
+++ b/spec/lambda_function_failed_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Deployment::Events::LambdaFunctionFailed do
     end
 
     describe(:error) do
-      it 'returns a generic Pre flight checks failed error message' do
-        expect(deployment.error).to start_with('Pre flight checks failed:')
+      it 'returns full preflight failure details' do
+        expect(deployment.error == '{"RequiredParameters":"FAILED","CommitCheck":"PASSED","ScheduleCheck":"PASSED","ForwardDeployCheck":"PASSED"}')
       end
     end
   end

--- a/spec/lambda_function_failed_spec.rb
+++ b/spec/lambda_function_failed_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Deployment::Events::LambdaFunctionFailed do
   subject(:deployment) { Deployment::Events::LambdaFunctionFailed.new(event) }
 
-  context 'forward deploy pre-flight check failed' do
+  context 'one pre flight check failed' do
     let(:event) do
       Aws::States::Types::HistoryEvent.new(
         type: 'LambdaFunctionFailed',
@@ -24,19 +24,19 @@ RSpec.describe Deployment::Events::LambdaFunctionFailed do
 
     describe(:error) do
       it 'returns the correct error message' do
-        expect(deployment.error).to start_with('Forward deploy check FAILED.')
+        expect(deployment.error).to start_with('The following pre-flight checks have failed: ForwardDeployCheck')
       end
     end
   end
 
-  context 'some other pre-flight check failed' do
+  context 'multiple pre flight checks failed' do
     let(:event) do
       Aws::States::Types::HistoryEvent.new(
         type: 'LambdaFunctionFailed',
         lambda_function_failed_event_details: Aws::States::Types::LambdaFunctionFailedEventDetails.new(
           cause: '
             {
-              "errorMessage": "Pre flight checks failed:\n{\"Checks\"=>{:RequiredParameters=>\"FAILED\", :CommitCheck=>\"PASSED\", :ScheduleCheck=>\"PASSED\", :ForwardDeployCheck=>\"PASSED\"}, \"Status\"=>\"FAILED\"}",
+              "errorMessage": "Pre flight checks failed:\n{\"Checks\"=>{:RequiredParameters=>\"FAILED\", :CommitCheck=>\"FAILED\", :ScheduleCheck=>\"FAILED\", :ForwardDeployCheck=>\"PASSED\"}, \"Status\"=>\"FAILED\"}",
               "errorType": "Function<StandardError>",
               "stackTrace": [
                 "/var/task/pre_flight_checks.rb:145:in `handler"
@@ -48,7 +48,7 @@ RSpec.describe Deployment::Events::LambdaFunctionFailed do
 
     describe(:error) do
       it 'returns full preflight failure details' do
-        expect(deployment.error == '{"RequiredParameters":"FAILED","CommitCheck":"PASSED","ScheduleCheck":"PASSED","ForwardDeployCheck":"PASSED"}')
+        expect(deployment.error).to start_with('The following pre-flight checks have failed: CommitCheck, RequiredParameters, ScheduleCheck.')
       end
     end
   end


### PR DESCRIPTION
- Pull the full errorMessage by default
- Only attempt to parse the preflight checks if it is a preflight error
- Otherwise just return the errorMessage passed
- eval the errorMessage into a Ruby object if we need to check the details of the object.

The eval is arguably a bit dangerous, but its locked behind the 'Pre flight checks failed' string being found in the error in the first place, and the .split()[1] not throwing an exception. So its probably OK. As we control the source. 