### PR TITLE
Use public ECR registry for pulling Ruby base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image
-FROM ruby:3.1.1
+FROM public.ecr.aws/docker/library/ruby:3.1.1
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
We're seeing 
```
429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

So, let's not use Docker Hub, and instead use the ECR Public Gallery.